### PR TITLE
Fix multiple backend service bugs

### DIFF
--- a/electron/database/database.ts
+++ b/electron/database/database.ts
@@ -252,7 +252,13 @@ class GrailDatabase {
   // Restore methods stay as full implementations because they mutate this.rawDb/this.db
   restore(backupPath: string): void {
     this.rawDb.close();
-    copyFileSync(backupPath, this.dbPath);
+    try {
+      copyFileSync(backupPath, this.dbPath);
+    } catch (error) {
+      this.rawDb = new Database(this.dbPath);
+      this.db = createDrizzleDb(this.rawDb);
+      throw error;
+    }
     this.rawDb = new Database(this.dbPath);
     this.db = createDrizzleDb(this.rawDb);
     this.initializeSchema();
@@ -260,7 +266,13 @@ class GrailDatabase {
 
   restoreFromBuffer(backupBuffer: Buffer): void {
     this.rawDb.close();
-    writeFileSync(this.dbPath, backupBuffer);
+    try {
+      writeFileSync(this.dbPath, backupBuffer);
+    } catch (error) {
+      this.rawDb = new Database(this.dbPath);
+      this.db = createDrizzleDb(this.rawDb);
+      throw error;
+    }
     this.rawDb = new Database(this.dbPath);
     this.db = createDrizzleDb(this.rawDb);
     this.initializeSchema();

--- a/electron/database/database.ts
+++ b/electron/database/database.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { app } from 'electron';
@@ -251,13 +251,25 @@ class GrailDatabase {
 
   // Restore methods stay as full implementations because they mutate this.rawDb/this.db
   restore(backupPath: string): void {
+    // Save current database so we can recover if the restore fails
+    const tempPath = `${this.dbPath}.pre-restore`;
+    copyFileSync(this.dbPath, tempPath);
+
     this.rawDb.close();
     try {
       copyFileSync(backupPath, this.dbPath);
     } catch (error) {
+      // Restore original database file from pre-restore backup
+      copyFileSync(tempPath, this.dbPath);
       this.rawDb = new Database(this.dbPath);
       this.db = createDrizzleDb(this.rawDb);
       throw error;
+    } finally {
+      try {
+        unlinkSync(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
     }
     this.rawDb = new Database(this.dbPath);
     this.db = createDrizzleDb(this.rawDb);
@@ -265,13 +277,25 @@ class GrailDatabase {
   }
 
   restoreFromBuffer(backupBuffer: Buffer): void {
+    // Save current database so we can recover if the restore fails
+    const tempPath = `${this.dbPath}.pre-restore`;
+    copyFileSync(this.dbPath, tempPath);
+
     this.rawDb.close();
     try {
       writeFileSync(this.dbPath, backupBuffer);
     } catch (error) {
+      // Restore original database file from pre-restore backup
+      copyFileSync(tempPath, this.dbPath);
       this.rawDb = new Database(this.dbPath);
       this.db = createDrizzleDb(this.rawDb);
       throw error;
+    } finally {
+      try {
+        unlinkSync(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
     }
     this.rawDb = new Database(this.dbPath);
     this.db = createDrizzleDb(this.rawDb);

--- a/electron/database/settings.ts
+++ b/electron/database/settings.ts
@@ -125,16 +125,6 @@ export function getAllSettings(ctx: DatabaseContext): Settings {
     ),
   };
 
-  // Migration: If runTrackerAutoStart was enabled, enable runTrackerMemoryReading
-  if (
-    settingsMap.runTrackerAutoStart === 'true' &&
-    settingsMap.runTrackerMemoryReading !== 'true'
-  ) {
-    console.log('[Database] Migrating runTrackerAutoStart to runTrackerMemoryReading (auto mode)');
-    typedSettings.runTrackerMemoryReading = true;
-    setSetting(ctx, 'runTrackerMemoryReading', 'true');
-  }
-
   return typedSettings;
 }
 

--- a/electron/database/settings.ts
+++ b/electron/database/settings.ts
@@ -10,14 +10,15 @@ function parseJSON(jsonString: string): unknown {
     return undefined;
   }
   if (jsonString === '[object Object]') {
+    console.warn(
+      '[parseJSON] Detected "[object Object]" string — an object was likely coerced to string before storage.',
+    );
     return undefined;
   }
   try {
     return JSON.parse(jsonString);
   } catch {
-    if (jsonString !== '[object Object]') {
-      console.warn(`Failed to parse JSON setting: "${jsonString}". Using undefined.`);
-    }
+    console.warn(`Failed to parse JSON setting: "${jsonString}". Using undefined.`);
     return undefined;
   }
 }

--- a/electron/services/DatabaseBatchWriter.ts
+++ b/electron/services/DatabaseBatchWriter.ts
@@ -154,12 +154,15 @@ export class DatabaseBatchWriter {
       );
 
       if (this.consecutiveFailures >= this.MAX_FLUSH_RETRIES) {
-        const dropped = {
+        const remaining = {
           characters: this.characterQueue.size,
           progress: this.progressQueue.size,
           runItems: this.runItemQueue.size,
         };
-        console.error(`[DatabaseBatchWriter] Max retries exceeded, dropping items:`, dropped);
+        console.error(
+          `[DatabaseBatchWriter] Max retries exceeded, dropping remaining unflushed items:`,
+          remaining,
+        );
         this.characterQueue.clear();
         this.progressQueue.clear();
         this.runItemQueue.clear();

--- a/electron/services/memoryReader.ts
+++ b/electron/services/memoryReader.ts
@@ -53,7 +53,8 @@ function queryMemoryRegion(
   const mbiBuffer = Buffer.alloc(48);
   const bytesReturned = k32.VirtualQueryEx(handle, address, mbiBuffer, 48);
 
-  if (bytesReturned === 0) {
+  // Need at least 40 bytes to read Protect at offset 36 (UInt32 = 4 bytes)
+  if (bytesReturned < 40) {
     return null;
   }
 

--- a/electron/services/saveFileMonitor.ts
+++ b/electron/services/saveFileMonitor.ts
@@ -998,9 +998,18 @@ class SaveFileMonitor {
       return () => this.processSingleFile(filePath, results);
     });
 
-    await this.executeConcurrently(tasks, this.MAX_CONCURRENT_PARSES);
+    const parseResults = await this.executeConcurrently(tasks, this.MAX_CONCURRENT_PARSES);
 
-    console.log('[parseFiles] Concurrent parsing complete');
+    const failedFiles = parseResults.filter((r) => r && !r.success);
+    if (failedFiles.length > 0) {
+      console.warn(
+        `[parseFiles] ${failedFiles.length} file(s) failed to parse:`,
+        failedFiles.map((f) => f.saveName),
+      );
+    }
+    console.log(
+      `[parseFiles] Concurrent parsing complete: ${filesToParse.length - failedFiles.length} succeeded, ${failedFiles.length} failed`,
+    );
 
     // Reset force parse flag after parsing completes
     if (this.forceParseAll) {


### PR DESCRIPTION
## Summary
- **Move settings migration out of getter**: `getAllSettings()` was calling `setSetting()` to auto-enable `runTrackerMemoryReading`, causing unexpected DB writes on every settings read. Moved to schema initialization alongside existing `ensureWizardSettings()` pattern.
- **Fix database restore recovery**: `restore()` and `restoreFromBuffer()` left the database handle invalid if the file copy/write failed after `close()`. Now catches the error, re-opens the original database, and re-throws.
- **Log `[object Object]` in parseJSON**: Silently returning `undefined` for this string hid real serialization bugs. Now logs a warning so the root cause can be traced. Also removed redundant dead-code guard in the catch block.
- **Add VirtualQueryEx bounds check**: `queryMemoryRegion` read buffer offsets 24/32/36 but only checked `bytesReturned === 0`. Now requires `>= 40` bytes to ensure all reads are within returned data.
- **Log failed file parse summary**: `parseFiles` discarded `processSingleFile` return values after concurrent execution. Now logs which files failed and a success/failure count.
- **Add DatabaseBatchWriter retry limit**: On flush error, items stayed in queue and the re-thrown error was unhandled from `setTimeout`. Permanently failing items retried forever. Now drops items after 3 consecutive failures with an error log, and stops re-throwing.

## Test plan
- [x] All 627 tests pass (1 new test added for retry limit behavior)
- [x] TypeScript type checking passes
- [x] Biome lint and format checks pass
- [x] Verify settings migration runs once at startup on existing databases with `runTrackerAutoStart=true`
- [x] Verify database restore falls back correctly when backup file is missing/corrupt
- [x] Verify `[object Object]` warning appears in logs when a setting is accidentally stored as coerced string

🤖 Generated with [Claude Code](https://claude.com/claude-code)