### PR TITLE
Fix resource cleanup in electron/services to prevent listener leaks

### DIFF
--- a/electron/ipc-handlers/saveFileHandlers.test.ts
+++ b/electron/ipc-handlers/saveFileHandlers.test.ts
@@ -38,6 +38,7 @@ vi.mock('../services/memoryReader', () => ({
   MemoryReader: vi.fn().mockImplementation(() => ({
     startPolling: vi.fn(),
     stopPolling: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
     updatePollingInterval: vi.fn(),
     isInGame: vi.fn().mockResolvedValue(false),
     readGameState: vi.fn().mockResolvedValue(null),
@@ -170,6 +171,7 @@ vi.mock('../services/saveFileMonitor', () => ({
   SaveFileMonitor: vi.fn().mockImplementation(() => ({
     startMonitoring: vi.fn(),
     stopMonitoring: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
     getSaveFiles: vi.fn(),
     isCurrentlyMonitoring: vi.fn(),
     getSaveDirectory: vi.fn(),
@@ -224,6 +226,7 @@ interface MockDatabaseBatchWriter {
 interface MockSaveFileMonitor {
   startMonitoring: ReturnType<typeof vi.fn>;
   stopMonitoring: ReturnType<typeof vi.fn>;
+  shutdown: ReturnType<typeof vi.fn>;
   getSaveFiles: ReturnType<typeof vi.fn>;
   isCurrentlyMonitoring: ReturnType<typeof vi.fn>;
   getSaveDirectory: ReturnType<typeof vi.fn>;
@@ -278,6 +281,7 @@ describe('When saveFileHandlers is used', () => {
     mockSaveFileMonitor = {
       startMonitoring: vi.fn().mockResolvedValue(undefined),
       stopMonitoring: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
       getSaveFiles: vi.fn().mockResolvedValue([]),
       isCurrentlyMonitoring: vi.fn().mockReturnValue(false),
       getSaveDirectory: vi.fn().mockReturnValue('/test/save/dir'),
@@ -880,7 +884,7 @@ describe('When saveFileHandlers is used', () => {
   });
 
   describe('If closeSaveFileMonitor is called', () => {
-    it('Then should stop monitoring', () => {
+    it('Then should shut down all services', () => {
       // Arrange
       initializeSaveFileHandlers();
 
@@ -889,7 +893,7 @@ describe('When saveFileHandlers is used', () => {
 
       // Assert
       expect(mockBatchWriter.flush).toHaveBeenCalled();
-      expect(mockSaveFileMonitor.stopMonitoring).toHaveBeenCalled();
+      expect(mockSaveFileMonitor.shutdown).toHaveBeenCalled();
     });
 
     it('Then should handle case when monitor is not initialized', () => {

--- a/electron/ipc-handlers/saveFileHandlers.ts
+++ b/electron/ipc-handlers/saveFileHandlers.ts
@@ -638,17 +638,17 @@ export function closeSaveFileMonitor(): void {
   console.log('[closeSaveFileMonitor] Flushing pending database writes');
   batchWriter.flush();
 
-  // Unsubscribe all event listeners
+  // Unsubscribe IPC handler event listeners
   for (const unsubscribe of eventUnsubscribers) {
     unsubscribe();
   }
   eventUnsubscribers.length = 0;
 
-  // Clear all event bus listeners
-  eventBus.clear();
+  // Shut down services (each cleans up its own EventBus listeners)
+  processMonitor?.shutdown();
+  memoryReader?.shutdown();
+  saveFileMonitor?.shutdown();
 
-  // Stop save file monitoring
-  if (saveFileMonitor) {
-    saveFileMonitor.stopMonitoring();
-  }
+  // Final safety net: clear any remaining EventBus listeners
+  eventBus.clear();
 }

--- a/electron/services/runTracker.test.ts
+++ b/electron/services/runTracker.test.ts
@@ -18,7 +18,7 @@ const mockDatabase: Partial<GrailDatabase> = {
 // Mock event bus
 const mockEventBus = {
   emit: vi.fn(),
-  on: vi.fn(),
+  on: vi.fn().mockReturnValue(vi.fn()),
   off: vi.fn(),
   listenerCount: vi.fn(() => 0),
   clear: vi.fn(),


### PR DESCRIPTION
## Summary

Audit and fix EventBus listener cleanup gaps in electron services:

- **RunTrackerService**: Capture `game-entered`/`game-exited` listeners and properly unsubscribe in `shutdown()`
- **MemoryReader**: Capture `d2r-started`/`d2r-stopped` listeners and properly unsubscribe in `shutdown()`
- **closeSaveFileMonitor()**: Call `shutdown()` on all services instead of just `stopMonitoring()`
  - Properly shuts down ProcessMonitor (stops the 2s check interval)
  - Properly shuts down MemoryReader (stops polling, closes process handle, unsubscribes listeners)
  - Calls `shutdown()` instead of `stopMonitoring()` on SaveFileMonitor (also clears the tick reader interval)

This prevents resource leaks during app quit and ensures robust cleanup against partial shutdowns and service recreation.

## Test Plan

- ✅ TypeScript type checking passes (`bun run typecheck`)
- ✅ All lint/format checks pass (`bun run check`)
- ✅ All 637 tests pass (`bun run test:run`)
- ✅ Updated test mocks to support new `shutdown()` methods

## Changes

| File | Changes |
|------|---------|
| `electron/services/runTracker.ts` | Added `eventUnsubscribers` field, capture listeners in `setupEventListeners()`, unsubscribe in `shutdown()` |
| `electron/services/memoryReader.ts` | Added `eventUnsubscribers` field, capture listeners in constructor, unsubscribe in `shutdown()` |
| `electron/ipc-handlers/saveFileHandlers.ts` | Updated `closeSaveFileMonitor()` to call `shutdown()` on ProcessMonitor, MemoryReader, and SaveFileMonitor |
| `electron/services/runTracker.test.ts` | Fixed mock: `eventBus.on()` now returns unsubscribe function |
| `electron/ipc-handlers/saveFileHandlers.test.ts` | Added `shutdown` to SaveFileMonitor/MemoryReader mocks, updated assertions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)